### PR TITLE
Phase 2 — absorb kubernetes role

### DIFF
--- a/ansible/roles/kubernetes/defaults/main.yml
+++ b/ansible/roles/kubernetes/defaults/main.yml
@@ -1,0 +1,34 @@
+---
+# Kubernetes Management Role - Default Variables
+
+# Cluster configuration
+k8s_cluster_name: "local-k8s"
+k8s_version: "1.28"
+k8s_network_plugin: "calico"
+
+# Node types
+k8s_control_plane_nodes: []
+k8s_worker_nodes: []
+k8s_lb_nodes: []
+
+# Health check settings
+k8s_health_check_timeout: 300
+k8s_health_check_retries: 3
+
+# kubectl configuration
+kubectl_config_path: "~/.kube/config"
+kubectl_context: "kubernetes-admin@kubernetes"
+
+# Node maintenance
+k8s_drain_timeout: 300
+k8s_drain_grace_period: 60
+k8s_drain_delete_local_data: true
+k8s_drain_ignore_daemonsets: true
+
+# Harbor integration
+harbor_registry: "harbor.devops-lab.cloud"
+harbor_secret_name: "harbor-pull-secret"
+
+# Monitoring
+k8s_metrics_enabled: true
+k8s_logging_enabled: true

--- a/ansible/roles/kubernetes/tasks/main.yml
+++ b/ansible/roles/kubernetes/tasks/main.yml
@@ -1,0 +1,67 @@
+---
+# Kubernetes Management Role - Main Tasks
+
+- name: Check kubectl availability
+  command: kubectl version --client --short
+  register: kubectl_version
+  changed_when: false
+  failed_when: false
+  delegate_to: localhost
+
+- name: Display kubectl version
+  debug:
+    msg: "kubectl version: {{ kubectl_version.stdout }}"
+  when: kubectl_version.rc == 0
+
+- name: Get cluster info
+  command: kubectl cluster-info
+  register: cluster_info
+  changed_when: false
+  failed_when: false
+  delegate_to: localhost
+
+- name: Display cluster info
+  debug:
+    msg: "{{ cluster_info.stdout_lines }}"
+  when: cluster_info.rc == 0
+
+- name: Get node status
+  command: kubectl get nodes -o wide
+  register: node_status
+  changed_when: false
+  failed_when: false
+  delegate_to: localhost
+
+- name: Display node status
+  debug:
+    msg: "{{ node_status.stdout_lines }}"
+  when: node_status.rc == 0
+
+- name: Check node health
+  command: kubectl get nodes -o json
+  register: nodes_json
+  changed_when: false
+  delegate_to: localhost
+
+- name: Parse node health status
+  set_fact:
+    unhealthy_nodes: "{{ (nodes_json.stdout | from_json).items | selectattr('status.conditions', 'defined') | selectattr('status.conditions', 'search', '\"type\": \"Ready\".*\"status\": \"False\"') | map(attribute='metadata.name') | list }}"
+  when: nodes_json.rc == 0
+
+- name: Report unhealthy nodes
+  debug:
+    msg: "WARNING: Unhealthy nodes detected: {{ unhealthy_nodes }}"
+  when:
+    - unhealthy_nodes is defined
+    - unhealthy_nodes | length > 0
+
+- name: Get pod status across all namespaces
+  command: kubectl get pods --all-namespaces -o wide
+  register: all_pods
+  changed_when: false
+  delegate_to: localhost
+
+- name: Display critical pods status
+  debug:
+    msg: "{{ all_pods.stdout_lines | select('search', 'kube-system|default') | list }}"
+  when: all_pods.rc == 0


### PR DESCRIPTION
Phase 2 of PLATFORM-PLAN-DETAILED.md extraction.

Source: ansible-central and/or devops-platform-iac
Target: this repo

**Verification required before merge:**
- [ ] Ansible lint passes on extracted roles/playbooks
- [ ] `ansible-playbook --check --diff` succeeds against target hosts
- [ ] molecule test (if role has molecule config)
- [ ] Idempotency verified (second run = 0 changed)

After merge: ansible-central and devops-platform-iac will be archived in final Phase 2 cleanup.

Co-authored-by: Kimi <154502+Kimi@users.noreply.github.com>