### PR TITLE
fix(ci): add issues/PR write perms to Slack stub

### DIFF
--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -19,6 +19,8 @@ permissions:
   contents: read
   actions: read
   checks: read
+  issues: write
+  pull-requests: write
 
 jobs:
   slack:


### PR DESCRIPTION
Fixes startup_failure on Slack workflow. Reusable workflow requires issues:write + pull-requests:write for threading (PR comment marker). Matches svc-platform stub.

Co-authored-by: Kimi <154502+Kimi@users.noreply.github.com>