### PR TITLE
chore(ci): add merge-to-dev workflow

### DIFF
--- a/.github/workflows/merge-to-dev.yml
+++ b/.github/workflows/merge-to-dev.yml
@@ -1,0 +1,71 @@
+# CEO-Gated Merge to Dev
+# Manually triggered — CEO selects the feature branch to merge into dev
+name: Merge to Dev
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Feature branch to merge into dev'
+        required: true
+        type: string
+      merge_strategy:
+        description: 'Merge strategy'
+        required: true
+        default: 'squash'
+        type: choice
+        options:
+          - squash
+          - merge
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: merge-to-dev
+  cancel-in-progress: false
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate branch exists
+        run: |
+          if ! git ls-remote --exit-code --heads origin "${{ inputs.branch }}" >/dev/null 2>&1; then
+            echo "❌ Branch '${{ inputs.branch }}' does not exist on remote"
+            exit 1
+          fi
+
+      - name: Merge to dev
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout dev
+          git pull origin dev
+
+          BRANCH="${{ inputs.branch }}"
+          STRATEGY="${{ inputs.merge_strategy }}"
+
+          if [ "$STRATEGY" = "squash" ]; then
+            git merge --squash "origin/$BRANCH"
+            COMMIT_MSG=$(git log --oneline "dev..origin/$BRANCH" | head -1 | cut -d' ' -f2-)
+            git commit -m "feat: $COMMIT_MSG (squash merge from $BRANCH)"
+          else
+            git merge --no-ff "origin/$BRANCH" -m "Merge $BRANCH into dev"
+          fi
+
+          git push origin dev
+
+      - name: Summary
+        run: |
+          echo "## ✅ Merged to dev" >> $GITHUB_STEP_SUMMARY
+          echo "- **Branch**: \`${{ inputs.branch }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Strategy**: ${{ inputs.merge_strategy }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Triggered by**: ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Deploys `merge-to-dev.yml` from `_GENERAL_RULES/gha-templates`. CEO-gated workflow_dispatch trigger for feature → dev merges, per PR-only policy.

Co-authored-by: Kimi <154502+Kimi@users.noreply.github.com>