### PR TITLE
chore(ci): rewrite uses: to devops-lab-cloud org

### DIFF
--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -24,6 +24,6 @@ permissions:
 
 jobs:
   slack:
-    uses: adsz/_GENERAL_RULES/.github/workflows/reusable-slack-all-events.yml@main
+    uses: devops-lab-cloud/_GENERAL_RULES/.github/workflows/reusable-slack-all-events.yml@main
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
Pin reusable workflow owner to new path after repo transfer.

Co-authored-by: Kimi <154502+Kimi@users.noreply.github.com>