### PR TITLE
chore(ci): require Mermaid diagram in PR bodies

### DIFF
--- a/.github/workflows/pr-diagram.yml
+++ b/.github/workflows/pr-diagram.yml
@@ -1,0 +1,10 @@
+---
+name: PR diagram check
+
+"on":
+  pull_request:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+jobs:
+  diagram:
+    uses: devops-lab-cloud/_GENERAL_RULES/.github/workflows/reusable-pr-diagram-check.yml@main


### PR DESCRIPTION
Deploys per-repo stub calling `reusable-pr-diagram-check.yml` from devops-lab-cloud/_GENERAL_RULES. Enforces CLAUDE.md PR Review Policy.

## Architecture

```mermaid
flowchart LR
  PR[Pull Request] --> Stub[.github/workflows/pr-diagram.yml]
  Stub -->|workflow_call| Central[reusable-pr-diagram-check.yml]
  Central --> Check{has mermaid block?}
  Check -->|yes| Pass[green]
  Check -->|no| Fail[red]
```

Skip labels: dependencies, skip-diagram, docs-only, auto-sync.

Co-authored-by: Kimi <154502+Kimi@users.noreply.github.com>