### PR TITLE
ci: migrate workflows to devops-lab-runners (ARC on P2 K8s)

### DIFF
--- a/.github/workflows/auto-promote.yml
+++ b/.github/workflows/auto-promote.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   wait-for-ci:
-    runs-on: ubuntu-latest
+    runs-on: devops-lab-runners
     if: ${{ github.event_name == 'push' || inputs.skip_ci_check != true }}
     outputs:
       ci_ok: ${{ steps.ci.outputs.ok }}
@@ -74,7 +74,7 @@ jobs:
   promote:
     needs: wait-for-ci
     if: ${{ always() && (needs.wait-for-ci.outputs.ci_ok == 'true' || inputs.skip_ci_check == true) }}
-    runs-on: ubuntu-latest
+    runs-on: devops-lab-runners
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: devops-lab-runners
     outputs:
       python: ${{ steps.filter.outputs.python }}
       frontend: ${{ steps.filter.outputs.frontend }}
@@ -61,7 +61,7 @@ jobs:
 
   lint:
     needs: changes
-    runs-on: ubuntu-latest
+    runs-on: devops-lab-runners
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -93,7 +93,7 @@ jobs:
 
   security:
     needs: changes
-    runs-on: ubuntu-latest
+    runs-on: devops-lab-runners
     env:
       VAULT_ADDR: https://vault-ol01.devops-lab.cloud
     steps:
@@ -117,7 +117,7 @@ jobs:
 
   test:
     needs: [changes, lint]
-    runs-on: ubuntu-latest
+    runs-on: devops-lab-runners
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -138,7 +138,7 @@ jobs:
   ci-status:
     needs: [lint, security, test]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: devops-lab-runners
     steps:
       - name: Check all jobs
         run: |

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -65,6 +65,12 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Setup Python
+        if: needs.changes.outputs.python == 'true' || needs.changes.outputs.ansible == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
       - name: Python lint
         if: needs.changes.outputs.python == 'true'
         run: |
@@ -120,6 +126,12 @@ jobs:
     runs-on: devops-lab-runners
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Python
+        if: needs.changes.outputs.python == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
 
       - name: Python tests
         if: needs.changes.outputs.python == 'true'

--- a/.github/workflows/enforcer.yml
+++ b/.github/workflows/enforcer.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   enforce:
-    runs-on: ubuntu-latest
+    runs-on: devops-lab-runners
     steps:
       - name: Check source branch
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1

--- a/.github/workflows/merge-to-dev.yml
+++ b/.github/workflows/merge-to-dev.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   merge:
-    runs-on: ubuntu-latest
+    runs-on: devops-lab-runners
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   gate:
-    runs-on: ubuntu-latest
+    runs-on: devops-lab-runners
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
       pr_number: ${{ steps.check.outputs.pr_number }}
@@ -66,7 +66,7 @@ jobs:
   expert-review:
     needs: gate
     if: needs.gate.outputs.should_run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: devops-lab-runners
     timeout-minutes: 30
     env:
       PR_NUMBER: ${{ needs.gate.outputs.pr_number }}


### PR DESCRIPTION
Migrates all ubuntu-latest jobs in this repo to devops-lab-runners (ARC self-hosted on P2 K8s).

**Why:** GitHub Actions billing on devops-lab-cloud org currently failing — ubuntu-latest jobs blocked. ARC runners are free, scale-to-zero, and already proven on svc-platform/svc-hetzner.

**Test plan:**
- [ ] CI runs on ARC runners
- [ ] All checks pass

Co-authored-by: Kimi <154502+Kimi@users.noreply.github.com>