### PR TITLE
🟠 (claude) [SVC-DOCS] security(openwiki): job-split hardening (audit C1)

### DIFF
--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -1,58 +1,56 @@
 ---
-# OpenWiki (langchain-ai) — per-repo code wiki for AI coding agents.
-# Generates the `openwiki/` folder and opens a PR to dev. Free Gemini Flash.
+# OpenWiki (langchain-ai) — per-repo code wiki for AI coding agents. Free Gemini Flash.
 #
-# SECURITY (BigTech supply-chain hardening):
-#   - every action pinned to a full commit SHA (no floating tags)
-#   - openwiki npm pinned to an exact version (not `latest`) — brand-new 3rd-party pkg
-#   - checkout persist-credentials:false — a compromised npm dep can't read a
-#     pushable token from .git/config (PR push uses a separate scoped App token)
-#   - deploy-bot App token (least-priv; GITHUB_TOKEN can't create PRs org-wide anyway)
-#   - Gemini free-tier key (low value) fetched from Vault via JWT OIDC, never logged
-#   - add-paths: openwiki  → only the openwiki/ dir is ever committed
-#   - ephemeral ARC runner (pod dies after the job)
+# SECURITY (BigTech, post-audit hardening — 2026-07-12):
+#   TWO-JOB SPLIT so the shell-capable agent NEVER shares a process with the
+#   deploy-bot App private key (audit C1):
+#     job `generate`  — runs openwiki (has a host `execute` shell). Vault role
+#                       `gha-openwiki` = LEAST PRIVILEGE, can read ONLY the
+#                       low-value Gemini free key. exportEnv:false → the key is
+#                       a masked STEP OUTPUT scoped to the run step, not job env.
+#                       Uploads the openwiki/ folder as an artifact. Never sees
+#                       the App key, never opens a PR.
+#     job `open-pr`   — no third-party code, no shell agent. Fetches the deploy-bot
+#                       key (role gha-cross-repo), mints an App token, downloads the
+#                       artifact, opens the PR (peter-evans, add-paths=openwiki).
+#   Supply-chain: openwiki pinned to an exact version + `--ignore-scripts`
+#   (no install lifecycle scripts run). Every action pinned to a full commit SHA.
+#   checkout persist-credentials:false. See svc-vault gha-openwiki policy/role.
+#   NOTE: arc-system egress allow-list (audit H2) is a separate infra control.
 
 name: OpenWiki Update
 
 "on":
   workflow_dispatch: {}
   schedule:
-    - cron: "0 6 * * 4"
+    - cron: "0 12 * * 1"
 
 permissions:
-  contents: write
-  pull-requests: write
-  id-token: write   # Vault OIDC (jwt-github)
+  contents: read
+  id-token: write
 
 concurrency:
   group: openwiki-update
   cancel-in-progress: false
 
 jobs:
-  update:
+  generate:
     runs-on: devops-lab-runners
     timeout-minutes: 30
     steps:
-      - name: Vault auth + fetch Gemini key + deploy-bot App key
+      - name: Vault — Gemini key only (least-priv role, no env export)
+        id: vault
         uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3
         with:
           url: https://vault.devops-lab.cloud
           method: jwt
-          path: jwt-github          # mount is jwt-github/, default jwt/ 403s
-          role: gha-cross-repo
+          path: jwt-github
+          role: gha-openwiki            # policy grants ONLY shared/kv/ai/gemini
+          exportEnv: false              # key -> masked step output, not job env
           secrets: |
-            shared/kv/data/ai/gemini api_key | GEMINI_API_KEY ;
-            shared/kv/data/github/deploy-bot app_id | GH_APP_ID ;
-            shared/kv/data/github/deploy-bot private_key | GH_APP_KEY
+            shared/kv/data/ai/gemini api_key | GEMINI_API_KEY
 
-      - name: Generate deploy-bot App token (for PR creation)
-        id: app-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
-        with:
-          app-id: ${{ env.GH_APP_ID }}
-          private-key: ${{ env.GH_APP_KEY }}
-
-      - name: Checkout (read-only creds — hardening)
+      - name: Checkout (read-only creds)
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
@@ -63,18 +61,67 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Install OpenWiki (pinned version — supply-chain)
-        run: npm install --global --no-fund --no-audit openwiki@0.1.1
+      - name: Install OpenWiki (pinned + no install scripts)
+        run: npm install --global --no-fund --no-audit --ignore-scripts openwiki@0.1.1
 
-      - name: Run OpenWiki (code mode)
-        run: openwiki code --update --print
+      - name: Run OpenWiki (code mode) — only the Gemini key is in this step's env
         env:
           OPENWIKI_PROVIDER: openai-compatible
           OPENWIKI_MODEL_ID: gemini-2.5-flash
           OPENAI_COMPATIBLE_BASE_URL: https://generativelanguage.googleapis.com/v1beta/openai
-          OPENAI_COMPATIBLE_API_KEY: ${{ env.GEMINI_API_KEY }}
+          OPENAI_COMPATIBLE_API_KEY: ${{ steps.vault.outputs.GEMINI_API_KEY }}
+        run: openwiki code --update --print
 
-      - name: Open OpenWiki update PR (deploy-bot token, add-paths=openwiki only)
+      - name: Upload openwiki/ artifact (only this folder crosses to the PR job)
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: openwiki-docs
+          path: openwiki/
+          if-no-files-found: ignore
+          retention-days: 1
+
+  open-pr:
+    needs: generate
+    runs-on: devops-lab-runners
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Vault — deploy-bot App key (no shell agent in this job)
+        id: vault
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3
+        with:
+          url: https://vault.devops-lab.cloud
+          method: jwt
+          path: jwt-github
+          role: gha-cross-repo
+          exportEnv: false
+          secrets: |
+            shared/kv/data/github/deploy-bot app_id | GH_APP_ID ;
+            shared/kv/data/github/deploy-bot private_key | GH_APP_KEY
+
+      - name: Mint deploy-bot App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ steps.vault.outputs.GH_APP_ID }}
+          private-key: ${{ steps.vault.outputs.GH_APP_KEY }}
+
+      - name: Checkout (read-only creds)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Download openwiki/ artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: openwiki-docs
+          path: openwiki/
+
+      - name: Open OpenWiki update PR (add-paths=openwiki only)
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -91,5 +138,7 @@ jobs:
             durable context for AI coding agents.
 
             - Scope: **`openwiki/` only** (does NOT touch CLAUDE.md / AGENTS.md).
-            - Engine: Google Gemini 2.5 Flash (GCP free tier, key from Vault).
+            - Engine: Gemini 2.5 Flash (GCP free tier).
+            - Security: generated in an isolated job that never holds the deploy-bot
+              key; openwiki version-pinned + `--ignore-scripts`.
             - Review the `openwiki/` diff before merging via `merge-to-dev`.


### PR DESCRIPTION
Security audit CRITICAL: deploy-bot App private key was job-wide env alongside openwiki's host shell (DeepAgents execute). Fix: split into generate (least-priv gha-openwiki role = ONLY gemini key, exportEnv:false, artifact) + open-pr (deploy-bot, no shell agent). openwiki pinned + --ignore-scripts, actions SHA-pinned. Replaces the v1 added earlier today (dev-only, cron inactive — no live exposure).